### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/apps/client/src/ipc/utils/git_utils.ts
+++ b/apps/client/src/ipc/utils/git_utils.ts
@@ -78,7 +78,7 @@ export async function gitCheckout({
 }): Promise<void> {
   const settings = readSettings();
   if (settings.enableNativeGit) {
-    await execAsync(`git -C "${path}" checkout "${ref.replace(/"/g, '\\"')}"`);
+    await execAsync(`git -C "${path}" checkout "${ref.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
     return;
   } else {
     return git.checkout({ fs, dir: path, ref });


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz18/bl1nk-skill-platform/security/code-scanning/9](https://github.com/billlzzz18/bl1nk-skill-platform/security/code-scanning/9)

The best way to fix the incomplete escaping is to replace both backslashes (`\`) and double quotes (`"`) in the `ref` string before interpolating it into the shell command. This prevents ambiguous meanings and injection vulnerabilities. The fix should use `.replace(/\\/g, '\\\\').replace(/"/g, '\\"')`, ensuring all backslashes are doubled, and all double quotes are escaped properly. We will update the line in apps/client/src/ipc/utils/git_utils.ts where `ref.replace(/"/g, '\\"')` is used, to perform both replacements. No new imports or changes outside that line are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in git branch and tag names to ensure safe command execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->