### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/apps/client/src/ipc/utils/git_utils.ts
+++ b/apps/client/src/ipc/utils/git_utils.ts
@@ -50,7 +50,7 @@ export async function gitCommit({
 }): Promise<string> {
   const settings = readSettings();
   if (settings.enableNativeGit) {
-    let command = `git -C "${path}" commit -m "${message.replace(/"/g, '\\"')}"`;
+    let command = `git -C "${path}" commit -m "${message.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
     if (amend) {
       command += " --amend";
     }


### PR DESCRIPTION
Potential fix for [https://github.com/billlzzz18/bl1nk-skill-platform/security/code-scanning/8](https://github.com/billlzzz18/bl1nk-skill-platform/security/code-scanning/8)

To correctly fix the issue, all meta-characters relevant to shell command construction must be safely escaped, not just `"` but also backslashes, and ideally anything that could break out of the quoted string or cause shell injection. In this case, since the string is enclosed in double quotes, every embedded backslash should be escaped before quotes, i.e., first escape all backslashes (`\` → `\\`), then all embedded double quotes (`"` → `\"`).  
The replacement should be on line 53: change the escaping to run `message.replace(/\\/g, '\\\\').replace(/"/g, '\\"')`, so backslashes are escaped first.  

Alternatively, the most robust fix is to use a well-known argument quoting library, such as `shell-quote`, but the current fix is only allowed to use such libraries if present or easy to add (and the brief suggests doing it inline if possible).

**Changes to make**:  
- Update line 53 in apps/client/src/ipc/utils/git_utils.ts to escape both backslashes and double quotes in the commit message, using chained `replace`.
- No further imports or definitions are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of commit messages containing backslashes and quotation marks in the native git commit path. These special characters now process correctly without errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->